### PR TITLE
Add basic tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Lint with flake8
+      run: |
+        flake8 lib main.py boot.py selftest.py tests
+
+    - name: Run tests
+      run: |
+        pytest -q

--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ Um das System ohne angeschlossene Sensoren zu testen, kann das Skript `selftest.
 import selftest
 selftest.run_selftest()
 ```
+
+## Tests
+
+Lokal lassen sich die Module mit `pytest` testen. Die Abhängigkeiten befinden
+sich in `requirements.txt`.
+
+```bash
+pytest
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -vv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+flake8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Ensure root directory is in path so tests can import project modules
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,0 +1,24 @@
+import math
+import pytest
+
+from lib.core.calc import TaupunktCalculator
+
+
+def test_dew_point_value():
+    dp = TaupunktCalculator.calculate_dew_point(20.0, 50.0)
+    assert 9.0 < dp < 10.0
+
+
+def test_invalid_humidity():
+    assert math.isnan(TaupunktCalculator.calculate_dew_point(25.0, 0))
+    assert math.isnan(TaupunktCalculator.calculate_dew_point(25.0, 150))
+
+
+def test_condensation_risk_levels():
+    calc = TaupunktCalculator()
+    level, _ = calc.evaluate_condensation_risk(10.0, 15.0, 2.0)
+    assert level == 'ok'
+    level, _ = calc.evaluate_condensation_risk(10.0, 12.5, 2.0)
+    assert level == 'warning'
+    level, _ = calc.evaluate_condensation_risk(10.0, 11.0, 2.0)
+    assert level == 'critical'

--- a/tests/test_calibrator.py
+++ b/tests/test_calibrator.py
@@ -1,0 +1,24 @@
+import pytest
+import os
+import json
+from lib.core.calc import SensorCalibrator
+
+
+def test_apply_calibration(tmp_path):
+    cal_file = tmp_path / "cal.json"
+    data = {"innen": {"temp_offset": 1.0, "humidity_offset": -2.0}}
+    cal_file.write_text(json.dumps(data))
+    calib = SensorCalibrator(config_path=str(cal_file))
+    temp, hum = calib.apply_calibration("innen", 20.0, 50.0)
+    assert temp == pytest.approx(21.0)
+    assert hum == pytest.approx(48.0)
+
+
+def test_set_and_save_calibration(tmp_path):
+    cal_file = tmp_path / "cal.json"
+    calib = SensorCalibrator(config_path=str(cal_file))
+    calib.set_calibration("innen", 0.5, 1.0)
+    with open(cal_file, "r") as f:
+        saved = json.load(f)
+    assert saved["innen"]["temp_offset"] == 0.5
+    assert saved["innen"]["humidity_offset"] == 1.0

--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -1,0 +1,11 @@
+from lib.core.trend import TrendAnalyzer
+
+
+def test_trend_computation():
+    analyzer = TrendAnalyzer(measurement_interval=60)
+    for i in range(5):
+        analyzer.add_measurement('innen', 20 + i)
+    data = analyzer.get_trend_data('innen', 24)
+    assert data.trend == 'rising'
+    assert data.current == 24
+    assert data.avg_5min > 20


### PR DESCRIPTION
## Summary
- add pytest test suite for core modules
- document how to run tests in README
- define Python requirements
- set up GitHub Actions workflow for linting and tests

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686921260a1c8324b091f782eaefa8fc